### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    commit-message:
-      prefix: ":pushpin:"


### PR DESCRIPTION
We manually manage actual dependency pins.