### PR TITLE
:pushpin: Add a check of node.js version for pyright.

### DIFF
--- a/ozi/lint/pyright/meson.build
+++ b/ozi/lint/pyright/meson.build
@@ -2,6 +2,16 @@
 # See LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 requirements = ['requirements.in']
+nodejs = find_program('node', version: '>12', required: false)
+if not nodejs.found()
+    warning(
+        'node version',
+        '>12',
+        'required by pyright version',
+        '>=1.1.352',
+        'not found'
+    )
+endif
 configure_file(
     input: requirements,
     output: 'requirements.txt',

--- a/ozi/lint/pyright/requirements.in
+++ b/ozi/lint/pyright/requirements.in
@@ -1,1 +1,1 @@
-pyright
+pyright>=1.1.352


### PR DESCRIPTION
* pins pyright to >=1.1.352, the version that pinned node >12