### PR TITLE
:bug: OZI.build 0.0.11 fixes for in-situ metadata generation

### DIFF
--- a/ozi/spec/ci.py
+++ b/ozi/spec/ci.py
@@ -174,7 +174,7 @@ class Build(Default):
     backend: str = 'ozi_build.buildapi'
     requires: Mapping[str, str] = field(
         default_factory=lambda: {
-            'OZI.build': 'OZI.build==0.0.9',
+            'OZI.build': 'OZI.build==0.0.11',
             'meson': 'meson[ninja]>=1.1.0',
             'pip-tools': 'pip-tools>=7',
             'setuptools': 'setuptools>=64',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 [build-system]
 build-backend = "ozi_build.buildapi"
 requires      = [
-    "OZI.build==0.0.9",
+    "OZI.build==0.0.11",
     "meson[ninja]>=1.1.0",
     "pip-tools>=7",
     "setuptools>=64",

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-blastpipe>=2024.2.6
+blastpipe==2024.2.10
 GitPython>=3
 dnspython
 idna>=2


### PR DESCRIPTION
* :arrow_up: OZI.build 0.0.9 for correct wheel names.



* :arrow_up::bug: Fix ``pyproject.toml:tool.ozi-build.metadata`` rendering.

Also updates the blastpipe pin to ``>=2024.4``



* :bug: fix pin



* :arrow_up::bug: Fix OZI.build missing builddir in checkpoint runs.



* :bug::arrow_up: OZI.build 0.0.11 fixes for in-situ metadata generation.



* :bug: revert blastpipe pin



---------