### PR TITLE
:pushpin:(requirements.in): ozi-templates>=2.0.5

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ dnspython
 idna>=2
 jinja2>=3
 meson[ninja]>=1.1.0
-ozi-templates>=2.0.4
+ozi-templates>=2.0.5
 packaging~=24.0
 pip-tools
 pyparsing~=3.1


### PR DESCRIPTION
(checkpoint.yml.j2): prerelease checkpoint no longer included