### PR TITLE
:fix:(meson.options): ``python-dependencies`` shouldnt yield to super…

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -25,7 +25,6 @@ option(
     type: 'array',
     description: 'sanity check module dependencies',
     value: ['setuptools_scm', 'piptools', 'setuptools', 'ninja', 'mesonbuild'],
-    yield: true,
 )
 
 option(


### PR DESCRIPTION
…project