### PR TITLE
:pushpin: ozi-core~=0.1.19

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-ozi-core~=0.1.18
+ozi-core~=0.1.19
 pip-tools~=7.4
 setuptools_scm[toml]
 tomli>=2.0.0;python_version<"3.11"


### PR DESCRIPTION
Cleans up calls to ``TAP.diagnostic``.