### PR TITLE
:sparkles: ozi-core 2.5 add invoke tasks and improve tox entrypoints

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -522,39 +522,44 @@ summary('install_env', get_option('python.install_env'), section: 'Python')
 summary('path', python.full_path(), section: 'Python')
 summary('version', python.language_version(), section: 'Python')
 
-installed_packages = []
-foreach line : run_command(pip, 'freeze', check: true).stdout().split('\n')
-    if line == ''
-        continue
-    endif
-    if not line.contains('@')
-        package = line.split('==')
-    else
-        package = line.split('@')
-    endif
-    if (
-        package[0] not in get_option('test-suite')
-        and package[0] not in get_option('lint-suite')
-        and package[0] not in get_option('dist-suite')
-    )
-        installed_packages += package[0]
-        summary(package[0], package[1].strip(), section: 'Python packages')
-    endif
-endforeach
+foreach name: namespace
+    if get_option(name).enabled() or dev.enabled()
+        installed_packages = []
+        foreach line : run_command(pip, 'freeze', check: true).stdout().split('\n')
+            if line == ''
+                continue
+            endif
+            if not line.contains('@')
+                package = line.split('==')
+            else
+                package = line.split('@')
+            endif
+            if (
+                package[0] not in get_option('test-suite')
+                and package[0] not in get_option('lint-suite')
+                and package[0] not in get_option('dist-suite')
+            )
+                installed_packages += package[0]
+                summary(package[0], package[1].strip(), section: 'Python packages')
+            endif
+        endforeach
 
-# Prior to Python 3.12 these would not be included in pip freeze
-# See: https://github.com/pypa/pip/pull/12032
-foreach legacy_package: ['wheel', 'setuptools', 'distribute']
-    if legacy_package not in installed_packages
-        legacy_package_version = run_command(
-            python,
-            ['-c', metadata_version.format(legacy_package)],
-            kwargs: no_check,
-        ).stdout().strip()
-        if legacy_package_version != ''
-            summary(legacy_package, legacy_package_version, section: 'Python packages')
-        endif
+        # Prior to Python 3.12 these would not be included in pip freeze
+        # See: https://github.com/pypa/pip/pull/12032
+        foreach legacy_package: ['wheel', 'setuptools', 'distribute']
+            if legacy_package not in installed_packages
+                legacy_package_version = run_command(
+                    python,
+                    ['-c', metadata_version.format(legacy_package)],
+                    kwargs: no_check,
+                ).stdout().strip()
+                if legacy_package_version != ''
+                    summary(legacy_package, legacy_package_version, section: 'Python packages')
+                endif
+            endif
+        endforeach
+        pip_version = run_command(pip, '-V', check: true).stdout().split()
+        summary(pip_version[0], pip_version[1], section: 'Python packages')
+        break  ### avoids repeating for each namespace making the above run once for *any*
     endif
 endforeach
-pip_version = run_command(pip, '-V', check: true).stdout().split()
-summary(pip_version[0], pip_version[1], section: 'Python packages')

--- a/ozi/tasks.py
+++ b/ozi/tasks.py
@@ -1,6 +1,11 @@
+# ozi/tasks.py
+# Part of the OZI Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [  # noqa: E800, RUF100
+#   'OZI.build',
 #   'build',
 #   'cibuildwheel',
 #   'invoke',
@@ -23,24 +28,22 @@ from invoke.tasks import task
 
 if TYPE_CHECKING:
     from invoke.context import Context
+    from invoke.runners import Result
 
 
 @task
-def setup(c: Context, suite: str = 'dist') -> None:
+def setup(c: Context, suite: str = 'dist', draft: bool = False) -> None | Result:
+    """Setup a meson build directory for an OZI suite."""
     target = Path(f'.tox/{suite}/tmp').absolute()  # noqa: S108
     env_dir = Path(f'.tox/{suite}').absolute()
     c.run(f'meson setup {target} -D{suite}=enabled -Dtox-env-dir={env_dir} --reconfigure')
+    if draft and suite == 'dist':
+        return c.run('psr --strict version')
 
 
 @task
-def checkpoint(c: Context, suite: str, maxfail: int = 1) -> None:
-    """Run OZI checkpoint suites with meson test."""
-    target = Path(f'.tox/{suite}/tmp').absolute()  # noqa: S108
-    c.run(f'meson test --no-rebuild --maxfail={maxfail} -C {target} --setup={suite}')
-
-
-@task
-def sign_log(c: Context, suite: str | None = None) -> None:
+def sign_checkpoint(c: Context, suite: str | None = None) -> None:
+    """Sign checkpoint suites with sigstore."""
     banned = './'
     host = f'py{sys.version_info.major}{sys.version_info.minor}'
     if not suite:
@@ -59,30 +62,31 @@ def sign_log(c: Context, suite: str | None = None) -> None:
         print(f'Meson log not found for suite: {suite}.', file=sys.stderr)
 
 
+@task
+def checkpoint(c: Context, suite: str, maxfail: int = 1) -> None:
+    """Run OZI checkpoint suites with meson test."""
+    target = Path(f'.tox/{suite}/tmp').absolute()  # noqa: S108
+    c.run(f'meson test --no-rebuild --maxfail={maxfail} -C {target} --setup={suite}')
+    sign_checkpoint(c, suite=suite)
+
+
 @task(
     pre=[
-        call(sign_log, suite='dist'),  # type: ignore
-        call(sign_log, suite='test'),  # type: ignore
-        call(sign_log, suite='lint'),  # type: ignore
+        call(checkpoint, suite='dist'),  # type: ignore
+        call(checkpoint, suite='test'),  # type: ignore
+        call(checkpoint, suite='lint'),  # type: ignore
     ],
 )
-def release(c: Context, sdist: bool = False) -> None:
-    """Create release wheels for the current interpreter.
-
-    :param c: invoke context
-    :type c: Context
-    :param sdist: create source distribution tarball, defaults to False
-    :type sdist: bool, optional
-    """
-    setup(c, suite='dist')
-    draft = c.run('psr --strict version')
-    if draft and draft.exited != 0:
+def release(c: Context, sdist: bool = False, draft: bool = False, cibuildwheel: bool = True) -> None:
+    """Create releases for the current interpreter."""
+    draft_ = setup(c, suite='dist', draft=draft)
+    if draft_ and draft_.exited != 0:
         return print('No release drafted.', file=sys.stderr)
     if sdist:
         c.run('python -m build --sdist')
         c.run('sigstore sign dist/*.tar.gz')
-    ext_wheel = c.run('cibuildwheel --prerelease-pythons --output-dir dist .')
-    if ext_wheel and ext_wheel.exited != 0:
+    ext_wheel = c.run('cibuildwheel --prerelease-pythons --output-dir dist .') if cibuildwheel else None
+    if (ext_wheel and ext_wheel.exited != 0) or cibuildwheel:
         c.run('python -m build --wheel')
     c.run('sigstore sign --output-dir=sig dist/*.whl')
 
@@ -94,7 +98,7 @@ def provenance(c: Context) -> None:
 
 
 @task(provenance)
-def publish(c: Context) -> None:
+def publish(c: Context, upload: bool = True) -> None:
     """Publishes a release tag"""
     c.run('psr publish')
     c.run('twine check dist/*')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,7 +382,7 @@ commands_pre =
      python -m uv pip install -r requirements.in OZI.build>=1.0.2 invoke~=2.2 pip-tools>=7 pipx~=1.5 setuptools_scm[toml]~=8.0
      pipx install --python=python meson
 commands =
-     meson setup {env_tmp_dir} -D{env_name}=enabled -Dtox-env-dir={env_dir}
+     meson setup {env_tmp_dir} -Ddist=disabled -Dtox-env-dir={env_dir}
      meson compile -C {env_tmp_dir}
      rm -rf {env_tmp_dir}/.gitignore
 commands_post =
@@ -418,10 +418,6 @@ commands_post =
 [testenv:invoke]
 description = OZI invoke task entrypoint, for more info use "tox -e invoke -- --list"
 no_package = true
-commands =
-     meson setup {env_tmp_dir} -Ddist=disabled -Dtox-env-dir={env_dir}
-     meson compile -C {env_tmp_dir}
-     rm -rf {env_tmp_dir}/.gitignore
 commands_post =
      {env_python} -m invoke --search-root={env_tmp_dir}/ozi {posargs:--list}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,5 +423,5 @@ commands =
      meson compile -C {env_tmp_dir}
      rm -rf {env_tmp_dir}/.gitignore
 commands_post =
-     {env_python} -m invoke --search-root={env_tmp_dir}/ozi {posargs}
+     {env_python} -m invoke --search-root={env_tmp_dir}/ozi {posargs:--list}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,11 @@
 build-backend = "ozi_build.buildapi"
 requires      = [
     "OZI.build>=1.0.2",
+    "invoke~=2.2",
     "pip-tools>=7",
-    'uv',
     "pipx~=1.5",
     "setuptools_scm[toml]~=8.0",
+    'uv',
 ]
 
 [tool.ozi-build.entry-points]
@@ -376,58 +377,51 @@ allowlist_externals =
     python
 package = wheel
 deps =
-     -r requirements.in
-     virtualenv
      uv
+commands_pre =
+     python -m uv pip install -r requirements.in OZI.build>=1.0.2 invoke~=2.2 pip-tools>=7 pipx~=1.5 setuptools_scm[toml]~=8.0
+     pipx install --python=python meson
 commands =
+     meson setup {env_tmp_dir} -D{env_name}=enabled -Dtox-env-dir={env_dir}
      meson compile -C {env_tmp_dir}
      rm -rf {env_tmp_dir}/.gitignore
+commands_post =
+     {env_python} -m invoke --search-root={env_tmp_dir}/ozi checkpoint --suite={env_name} {posargs}
 
 [testenv:dist]
 description = OZI distribution checkpoint
-commands_pre =
-    pipx install --python=python meson
-    meson setup {env_tmp_dir} -Ddist=enabled -Dtox-env-dir={env_dir}
-commands_post = meson test --no-rebuild --maxfail=1 -C {env_tmp_dir} --setup=dist {posargs}
 
 [testenv:lint]
 description = OZI format/lint checkpoint
-commands_pre =
-    pipx install --python=python meson
-    meson setup {env_tmp_dir} -Dlint=enabled -Dtox-env-dir={env_dir}
-commands_post = meson test --no-rebuild --maxfail=1 -C {env_tmp_dir} --setup=lint {posargs}
 
 [testenv:test]
 description = OZI unit tests checkpoint
-commands_pre =
-    pipx install --python=python meson
-    meson setup {env_tmp_dir} -Dtest=enabled -Dozi-blastpipe=enabled -Dtox-env-dir={env_dir} {posargs}
-commands_post = meson test --no-rebuild --maxfail=1 -C {env_tmp_dir} --setup=test
 
 [testenv:fix]
 description = OZI project fix issues utility (black, isort, autoflake, ruff)
 deps = pipx
 skip_install = true
+commands_pre =
 commands =
      pipx run --python {env_python} black -S .
      pipx run --python {env_python} isort .
      pipx run --python {env_python} autoflake -i -r .
      pipx run --python {env_python} ruff check ozi --fix
+commands_post =
 
 [testenv:scm]
 description = OZI supply chain management (setuptools_scm)
-deps =
-     setuptools_scm[toml]>=8
 commands =
      {env_python} -m setuptools_scm {posargs}
+commands_post =
 
 [testenv:invoke]
+description = OZI invoke task entrypoint, for more info use "tox -e invoke -- --list"
 no_package = true
-deps =
-    -r requirements.in
-commands_pre =
-    pipx install --python=python meson
-    meson setup {env_tmp_dir} -Ddist=enabled -Dtox-env-dir={env_dir}
+commands =
+     meson setup {env_tmp_dir} -Ddist=disabled -Dtox-env-dir={env_dir}
+     meson compile -C {env_tmp_dir}
+     rm -rf {env_tmp_dir}/.gitignore
 commands_post =
-    {env_python} -m invoke --search-root={env_tmp_dir}/ozi {posargs}
+     {env_python} -m invoke --search-root={env_tmp_dir}/ozi {posargs}
 """

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-ozi-core~=0.2.4
-pip-tools~=7.4
+ozi-core~=0.3.0
 setuptools_scm[toml]
 tomli>=2.0.0;python_version<"3.11"

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-invoke~=2.2
 ozi-core~=0.2.4
 pip-tools~=7.4
 setuptools_scm[toml]


### PR DESCRIPTION
Using the invoke backend speeds up our checkpoints by 30%. ozi-spec 0.7 adds invoke to build-system dependencies. ozi-templates 2.9 improves tox checkpoint testenvs to use invoke and improved support for uv. Prior to now pip installed all dependencies for tox checkpoints, even with ``--enable-uv``.