### PR TITLE
:arrow_down: sigstore~=3.0

### DIFF
--- a/ozi/dist/sigstore/requirements.in
+++ b/ozi/dist/sigstore/requirements.in
@@ -1,1 +1,1 @@
-sigstore~=3.3
+sigstore~=3.0


### PR DESCRIPTION
This should always match the version in sigstore/sigstore-gh-action used in OZI-Project/release and OZI-Project/checkpoint.