### PR TITLE
:sparkles: OZI.build 1.13

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,13 +5,10 @@
 project(
     'OZI',
     version: run_command(
-        'python3',  # scm_version_snip
+        'python3',
         [
             '-c',
-            '''from setuptools_scm import get_version
-v = get_version(normalize=False, fallback_version="wrap-file")
-print(v)
-''',
+            'from setuptools_scm import get_version;print(get_version(normalize=False, fallback_version="%OZIBUILDVERSION%"))',
         ],
         check: true,
     ).stdout().strip(),
@@ -23,6 +20,7 @@ print(v)
 env = environment()
 fs = import('fs')
 pymod = import('python')
+patch = find_program('patch')
 pyproject_config = configuration_data()
 
 # prescript arrays

--- a/ozi/meson.build
+++ b/ozi/meson.build
@@ -20,6 +20,7 @@ source_children = [
     'new',
     'scripts',
     'test',
+    'patch'
 ]
 foreach child: source_children
     subdir(child)

--- a/ozi/patch/README
+++ b/ozi/patch/README
@@ -1,0 +1,5 @@
+# meson.build patches
+
+This folder contains patches of the format ``(target filename)-(descriptive name)-(version).patch`` in a directory structure mirroring ``ozi-templates``.
+
+

--- a/ozi/patch/meson.build
+++ b/ozi/patch/meson.build
@@ -1,0 +1,19 @@
+# ozi/patch/meson.build
+# Part of the OZI Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+patch_files = [
+    'meson.build-fallback_version_for_ozi_build_1.13.0-1.38.0.patch'
+]
+foreach file: patch_files
+    if not meson.is_subproject() or get_option('install-subprojects').enabled()
+        python.install_sources(file, subdir: 'ozi'/'patch')
+    endif
+    fs.copyfile(file)
+    if meson.project_version().version_compare('<'+file.split('-')[2])
+        run_command(patch, '-Nmlu', '--no-backup-if-mismatch', meson.global_source_root() / file.split('-')[0], file, check: false)
+    endif
+endforeach
+if false
+    executable('source_child_patch', patch_files)
+endif

--- a/ozi/patch/meson.build-fallback_version_for_ozi_build_1.13.0-1.38.0.patch
+++ b/ozi/patch/meson.build-fallback_version_for_ozi_build_1.13.0-1.38.0.patch
@@ -1,0 +1,9 @@
+@@ -13,7 +13,7 @@
+         'python3',
+         [
+             '-c',
+-            'from setuptools_scm import get_version;print(get_version(normalize=False))',
++            'from setuptools_scm import get_version;print(get_version(normalize=False, fallback_version="%OZIBUILDVERSION%"))',
+         ],
+         check: true,
+     ).stdout().strip(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 dynamic = ["version"]
 dependencies = [
     'pathvalidate~=3.2.1',
-    'ozi-core==1.16.0',
+    'ozi-core==1.17.0',
     'setuptools_scm[toml]',
     'tomli>=2.0.0;python_version<"3.11"',
 ]


### PR DESCRIPTION
Fixes deprecated dist filename format in tarballs.