### PR TITLE
:pushpin: pytest~=8.3.0 because pytest 8.4 causes issues with coverag…

### DIFF
--- a/ozi/test/pytest/requirements.in
+++ b/ozi/test/pytest/requirements.in
@@ -1,4 +1,4 @@
-pytest~=8.3
+pytest~=8.3.0
 pytest-asyncio~=1.0.0
 pytest-cov~=6.1
 pytest-randomly~=3.16


### PR DESCRIPTION
…e+xdist